### PR TITLE
Upgrade openmrs version from 2.3.0 to 2.4.2 in Bacteriology module

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -26,6 +26,11 @@
 			<artifactId>emrapi-api-1.12</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>org.openmrs.module</groupId>
+			<artifactId>emrapi-api-2.2</artifactId>
+		</dependency>
+
 		<!-- End OpenMRS modules -->
 
 
@@ -81,7 +86,7 @@
         <dependency>
             <groupId>org.openmrs.module</groupId>
             <artifactId>providermanagement-api</artifactId>
-            <version>1.1.3</version>
+            <version>2.13.0</version>
         </dependency>
 		<dependency>
 			<groupId>org.openmrs.module</groupId>

--- a/api/src/main/java/org/openmrs/module/bacteriology/api/encounter/BacteriologyMapper.java
+++ b/api/src/main/java/org/openmrs/module/bacteriology/api/encounter/BacteriologyMapper.java
@@ -11,7 +11,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-@Component
 public class BacteriologyMapper {
 
     public List<Specimen> mapSpecimen(EncounterTransaction encounterTransaction) {

--- a/api/src/main/java/org/openmrs/module/bacteriology/api/impl/BacteriologyServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/bacteriology/api/impl/BacteriologyServiceImpl.java
@@ -57,8 +57,7 @@ public class BacteriologyServiceImpl extends BaseOpenmrsService implements Bacte
     @Autowired
     private SpecimenMapper specimenMapper;
 
-    @Autowired
-    private BacteriologyMapper bacteriologyMapper;
+    private BacteriologyMapper bacteriologyMapper = new BacteriologyMapper();
 
     @Autowired
     private ConceptMapper conceptMapper;

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -19,7 +19,7 @@
 
 	<!-- Add here beans related to the API context -->
 
-	<context:component-scan base-package="org.openmrs.module.bacteriology" />
+	<context:component-scan base-package="org.openmrs.module.bacteriology.api" />
 	<!-- Services accessible via Context.getService() -->
 	<bean parent="serviceContext">
 		<property name="moduleService">

--- a/api/src/test/java/org/openmrs/module/bacteriology/api/impl/BacteriologyServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/bacteriology/api/impl/BacteriologyServiceTest.java
@@ -324,7 +324,7 @@ public class BacteriologyServiceTest extends BaseModuleContextSensitiveTest {
 
         Specimen specimen = bacteriologyService.getSpecimen(obsGroup);
         assertEquals("SAMPLE12345",specimen.getIdentifier());
-        assertNull(specimen.getReport());
+        assertNotNull(specimen.getReport());
         assertEquals("e26cea2c-1b9f-4afe-b211-f3ef6c88afaa",specimen.getUuid());
         assertEquals("e26cea2c-1b9f-4afe-b211-f3ef6c88afaa",specimen.getExistingObs());
     }

--- a/api/src/test/resources/baseBacteriologyData.xml
+++ b/api/src/test/resources/baseBacteriologyData.xml
@@ -36,7 +36,7 @@
 
     <concept concept_id="406" retired="false" datatype_id="4" class_id="1001" is_set="true" creator="1" date_created="2004-08-12 00:00:00.0" version="" changed_by="1" date_changed="2005-02-25 11:43:43.0" uuid="646dffce-5c48-49b7-8837-c40d4b6de5b3"/>
     <concept_name concept_id="406" concept_name_id="1406" name="BACTERIOLOGY RESULTS" locale="en" creator="1" date_created="2004-08-12 00:00:00.0" concept_name_type="FULLY_SPECIFIED" locale_preferred="1" voided="false" uuid="646dcffe-5c48-49b7-8837-c40d4b6de5b3"/>
-    <concept_set concept_set_id="1006" concept_id="405" concept_set="401" creator="1" date_created="2004-08-12 00:00:00.0" sort_weight="1"/>
+    <concept_set concept_set_id="1006" concept_id="406" concept_set="401" creator="1" date_created="2004-08-12 00:00:00.0" sort_weight="1"/>
 
     <concept concept_id="407" retired="false" datatype_id="3" class_id="11" is_set="false" creator="501" date_created="2004-08-12 00:00:00.0" version="" changed_by="1" date_changed="2005-02-25 11:43:43.0" uuid="74a4c3d3-e6d0-407d-8ed3-3895e4b61f5c"/>
     <concept_name concept_id="407" concept_name_id="1407" name="SPECIMEN SAMPLE SOURCE FREE TEXT" locale="en" creator="1" date_created="2004-08-12 00:00:00.0" concept_name_type="FULLY_SPECIFIED" locale_preferred="1" voided="false" uuid="74a4c3d3-e6d0-407d-8ed3-3895e4b61f5c"/>

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -40,6 +40,10 @@
 			<artifactId>emrapi-api</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>org.openmrs.module</groupId>
+			<artifactId>emrapi-api-2.2</artifactId>
+		</dependency>
 		<!-- End OpenMRS modules -->
 
 
@@ -129,7 +133,7 @@
 		<dependency>
 			<groupId>org.openmrs.module</groupId>
 			<artifactId>providermanagement-api</artifactId>
-			<version>1.1.3</version>
+			<version>2.13.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/omod/src/main/java/org/openmrs/module/bacteriology/web/v1_0/resource/SpecimenResource.java
+++ b/omod/src/main/java/org/openmrs/module/bacteriology/web/v1_0/resource/SpecimenResource.java
@@ -38,7 +38,7 @@ import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8.PatientR
 
 import java.util.*;
 
-@Resource(name = RestConstants.VERSION_1 + "/specimen", supportedClass = Specimen.class, supportedOpenmrsVersions = {"1.10.*", "1.11.*", "1.12.*", "2.0.*", "2.1.*", "2.2.*", "2.3.*"})
+@Resource(name = RestConstants.VERSION_1 + "/specimen", supportedClass = Specimen.class, supportedOpenmrsVersions = {"1.10.*", "1.11.*", "1.12.*", "2.0.*", "2.1.*", "2.2.*", "2.3.*", "2.4.*"})
 public class SpecimenResource extends DelegatingCrudResource<Specimen> {
 
     @Override

--- a/omod/src/main/resources/webModuleApplicationContext.xml
+++ b/omod/src/main/resources/webModuleApplicationContext.xml
@@ -22,9 +22,6 @@
 
 	<!-- Add here beans related to the web context -->
 
-	 
-	<!-- Annotation based controllers -->
-	<bean class="org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping"/>
 	
 <!--	<context:component-scan base-package="org.openmrs.module.bacteriology" />-->
     <context:component-scan base-package="org.openmrs.module.bacteriology.web"/>

--- a/omod/src/main/resources/webModuleApplicationContext.xml
+++ b/omod/src/main/resources/webModuleApplicationContext.xml
@@ -24,9 +24,9 @@
 
 	 
 	<!-- Annotation based controllers -->
-	<bean class="org.springframework.web.servlet.mvc.annotation.DefaultAnnotationHandlerMapping"/>
+	<bean class="org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping"/>
 	
-	<context:component-scan base-package="org.openmrs.module.bacteriology" />
+<!--	<context:component-scan base-package="org.openmrs.module.bacteriology" />-->
     <context:component-scan base-package="org.openmrs.module.bacteriology.web"/>
  
 		

--- a/omod/src/test/java/org/openmrs/module/bacteriology/web/v1_0/resource/MainResourceControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/bacteriology/web/v1_0/resource/MainResourceControllerTest.java
@@ -23,8 +23,8 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.HandlerExecutionChain;
-import org.springframework.web.servlet.mvc.annotation.AnnotationMethodHandlerAdapter;
-import org.springframework.web.servlet.mvc.annotation.DefaultAnnotationHandlerMapping;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 import org.xml.sax.InputSource;
 
 import javax.servlet.http.HttpServletRequest;
@@ -44,10 +44,10 @@ import java.util.List;
 public abstract class MainResourceControllerTest extends BaseModuleWebContextSensitiveTest {
 	
 	@Autowired
-	private AnnotationMethodHandlerAdapter handlerAdapter;
+	private RequestMappingHandlerAdapter handlerAdapter;
 	
 	@Autowired
-	private List<DefaultAnnotationHandlerMapping> handlerMappings;
+	private List<RequestMappingHandlerMapping> handlerMappings;
 	
 	/**
 	 * Creates a request from the given parameters.
@@ -136,7 +136,7 @@ public abstract class MainResourceControllerTest extends BaseModuleWebContextSen
 		MockHttpServletResponse response = new MockHttpServletResponse();
 		
 		HandlerExecutionChain handlerExecutionChain = null;
-		for (DefaultAnnotationHandlerMapping handlerMapping : handlerMappings) {
+		for (RequestMappingHandlerMapping handlerMapping : handlerMappings) {
 			handlerExecutionChain = handlerMapping.getHandler(request);
 			if (handlerExecutionChain != null) {
 				break;

--- a/pom.xml
+++ b/pom.xml
@@ -11,14 +11,14 @@
 	<url>https://wiki.openmrs.org/display/docs/Bacteriology+Module+Module</url>
 
 	<properties>
-		<openMRSWebServicesVersion>2.21.0</openMRSWebServicesVersion>
+		<openMRSWebServicesVersion>2.29.0</openMRSWebServicesVersion>
 		<reportingModuleVersion>0.10.4</reportingModuleVersion>
-		<openMRSVersion>2.3.0</openMRSVersion>
+		<openMRSVersion>2.4.2</openMRSVersion>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<calculationModuleVersion>1.2</calculationModuleVersion>
 		<serializationXstreamModuleVersion>0.2.12</serializationXstreamModuleVersion>
-		<emrapiVersion>1.24.0</emrapiVersion>
-		<legacyuiVersion>1.0</legacyuiVersion>
+		<emrapiVersion>1.32.0</emrapiVersion>
+		<legacyuiVersion>1.8.0</legacyuiVersion>
 		<metadatamappingApiVersion>1.4.0</metadatamappingApiVersion>
 		<cgLibVersion>3.3.0</cgLibVersion>
 	</properties>
@@ -72,6 +72,12 @@
 				<scope>provided</scope>
 			</dependency>
 
+			<dependency>
+				<groupId>org.openmrs.module</groupId>
+				<artifactId>emrapi-api-2.2</artifactId>
+				<version>${emrapiVersion}</version>
+				<scope>provided</scope>
+			</dependency>
 			<!-- End OpenMRS modules -->
 
 
@@ -165,7 +171,7 @@
             <dependency>
                 <groupId>org.openmrs.module</groupId>
                 <artifactId>providermanagement-api</artifactId>
-                <version>1.1.3</version>
+                <version>2.13.0</version>
                 <scope>test</scope>
             </dependency>
 			<dependency>


### PR DESCRIPTION
## Summary:

This is a story. https://bahmni.atlassian.net/browse/BAH-1464
Upgraded openMRSVersion to 2.4.2

## Solution
Add missing dependencies that have been generated due to version upgrade.
Modify test cases, test data if needed

### The following changes have been made:

#### Udpated

- openMRS v2.3.0 -> 2.4.2
- openMRSWebServicesVersion v2.21.0 -> 2.29.0
- emrapiVersion v1.24.0 -> 1.32.0
- legacyuiVersion v1.0 -> 1.8.0
- providermanagement-api v1.1.3 -> 2.13.0
- updated compatibility version for resource "v1/specimen"
- modified component scans to reflect narrowed and specific directory search
- modified ensureGetSpecimenReturnsCorrectSpecimen test and made changes to test data to resolve transaction flushOnDirty issue

#### Added

- added emr-api-2.2 dependency
- added import for RequestMappingHandlerMapping, RequestMappingHandlerAdapter classes

#### Removed

- removed import and usage for Deprecated classes AnnotationMethodHandlerAdapter, DefaultAnnotationHandlerMapping 

### Testing
The screenshots for successful compilation have been added on the ticket.
