### PR TITLE
BAH-1835  Upgrade openmrs version from 2.4.2 to 2.5.0 in Bacteriology module

### DIFF
--- a/omod/src/main/java/org/openmrs/module/bacteriology/web/v1_0/resource/SpecimenResource.java
+++ b/omod/src/main/java/org/openmrs/module/bacteriology/web/v1_0/resource/SpecimenResource.java
@@ -38,7 +38,7 @@ import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8.PatientR
 
 import java.util.*;
 
-@Resource(name = RestConstants.VERSION_1 + "/specimen", supportedClass = Specimen.class, supportedOpenmrsVersions = {"1.10.*", "1.11.*", "1.12.*", "2.0.*", "2.1.*", "2.2.*", "2.3.*", "2.4.*"})
+@Resource(name = RestConstants.VERSION_1 + "/specimen", supportedClass = Specimen.class, supportedOpenmrsVersions = {"1.10.*", "1.11.*", "1.12.*", "2.0.*", "2.1.*", "2.2.*", "2.3.*", "2.4.*", "2.5.*"})
 public class SpecimenResource extends DelegatingCrudResource<Specimen> {
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	<properties>
 		<openMRSWebServicesVersion>2.29.0</openMRSWebServicesVersion>
 		<reportingModuleVersion>0.10.4</reportingModuleVersion>
-		<openMRSVersion>2.4.2</openMRSVersion>
+		<openMRSVersion>2.5.0</openMRSVersion>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<calculationModuleVersion>1.2</calculationModuleVersion>
 		<serializationXstreamModuleVersion>0.2.12</serializationXstreamModuleVersion>


### PR DESCRIPTION
### Summary:

This is a story. https://bahmni.atlassian.net/browse/BAH-1835
Upgraded openMRSVersion to 2.5.0

### Solution
Add missing dependencies that have been generated due to version upgrade.

## The following changes have been made:

- udpated
openMRS v2.4.2 -> 2.5.0
updated compatibility version for resource "v1/specimen"


### Testing
The screenshots for successful compilation have been added on the ticket.
